### PR TITLE
ci: drop XC_VERSION pin and use generic iOS Simulator destination

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: macos-latest
     env:
-      XC_VERSION: 15.4
+      XC_VERSION: 16.4
     steps:
       - name: Activate configured Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XC_VERSION.app"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,7 @@ on:
 jobs:
   build:
     runs-on: macos-latest
-    env:
-      XC_VERSION: 16.4
     steps:
-      - name: Activate configured Xcode
-        run: "sudo xcode-select -s /Applications/Xcode_$XC_VERSION.app"
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -37,7 +32,7 @@ jobs:
           xcodebuild -list -workspace "Swift/AdGemTester.xcworkspace"
 
       - name: Build Objective-C workspace
-        run: /usr/bin/xcodebuild -workspace "Obj-C/AdGem-ObjC.xcworkspace" -scheme "AdGem" -destination 'platform=iOS Simulator,name=iPhone 11' build
+        run: /usr/bin/xcodebuild -workspace "Obj-C/AdGem-ObjC.xcworkspace" -scheme "AdGem" -destination 'generic/platform=iOS Simulator' build
 
       - name: Build Swift workspace
-        run: /usr/bin/xcodebuild -workspace "Swift/AdGemTester.xcworkspace" -scheme "AdGem" -destination 'platform=iOS Simulator,name=iPhone 11' build
+        run: /usr/bin/xcodebuild -workspace "Swift/AdGemTester.xcworkspace" -scheme "AdGem" -destination 'generic/platform=iOS Simulator' build


### PR DESCRIPTION
## Summary

Drops the `XC_VERSION` pin (and the `xcode-select` step that used it) from `build.yml`, and switches both build steps' simulator destination from `name=iPhone 11` to `generic/platform=iOS Simulator`.

## Why

Two CI-rot issues had to be addressed together:

1. **Xcode 15.4 is no longer on the runner.** The macos-latest runner (macos-15) ships with Xcode 16.0–16.4 plus the 26.x series, with 16.4 as the symlinked default. The previous `xcode-select -s /Applications/Xcode_15.4.app` step was failing every build.
2. **iPhone 11 simulator is no longer on the runner.** The macos-15 runner installs iPhone 16 / 16 Plus / 16 Pro / 16 Pro Max / 16e / SE (3rd gen) for iOS 18.5.

A sample app doesn't need a specific Xcode pin, so dropping `XC_VERSION` entirely lets CI inherit the runner's current default automatically. Switching to `generic/platform=iOS Simulator` for the destination self-maintains as future device names rotate — and since both build steps are build-only (no tests), xcodebuild doesn't need a concrete simulator.

Unblocks #17 and any future PR in this repo.

## Test plan

- [ ] Confirm the `build` job passes on this PR
- [ ] Rebase #17 (`@dependabot rebase`) after merge and confirm its build job also recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)