### PR TITLE
ci: use deps prefix for Dependabot and allow it in PR title lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,8 @@ updates:
       interval: "monthly"
     rebase-strategy: disabled
     commit-message:
-      prefix: "build(actions-deps)"
-      prefix-development: "build(actions-deps-dev)"
+      prefix: "deps(actions-deps)"
+      prefix-development: "deps(actions-deps-dev)"
     reviewers:
       - "@AdGem/devops"
       - "@AdGem/sdk-developers"

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -29,5 +29,6 @@ jobs:
             test
             style
             perf
+            deps
           validateSingleCommit: true
 


### PR DESCRIPTION
Standardize Dependabot to the `deps` commit prefix and allow `deps` in the PR-title lint (dropping `chore` where present). Part of an org-wide cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated commit message conventions for automated dependency updates to use consistent semantic commit formatting
  * Enhanced pull request validation to recognize dependency-related changes in semantic commit checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->